### PR TITLE
allow easy usage of XML & .properties for plugin configuration.

### DIFF
--- a/PluginReference/src/main/java/PluginReference/configuration/prop/PropConfiguration.java
+++ b/PluginReference/src/main/java/PluginReference/configuration/prop/PropConfiguration.java
@@ -1,0 +1,78 @@
+package PluginReference.configuration.prop;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * .properties file editer,
+ * Configuration for plugins.
+ * 
+ * @author Isaiah Patton
+ * @version 1.0.0
+ * @see java.util.Properties
+ */
+public class PropConfiguration {
+    public File file;
+
+    public PropConfiguration(File f) {
+        this.file = f;
+    }
+    
+    /**
+     * Sets field to new text
+     */
+    public void set(String field, String text){
+        try {
+			Properties properties = new Properties();
+            properties.load(new FileInputStream(file));
+			properties.setProperty(field, text);
+
+			FileOutputStream fileOut = new FileOutputStream(file);
+			properties.store(fileOut, " ");
+			fileOut.close();
+		} catch (FileNotFoundException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+    }
+    
+    /**
+     * Returns the field text.
+     * 
+     * @return String
+     */
+ 	public String get(String field) throws FileNotFoundException {
+        FileInputStream in = new FileInputStream(file);
+ 		Properties prop = new Properties();
+        try {
+ 			prop.load(in);
+ 		} catch (IOException e1) {
+ 			e1.printStackTrace();
+ 		}
+        try {
+ 			in.close();
+ 		} catch (IOException e1) {
+ 			e1.printStackTrace();
+ 		}
+ 	    return prop.getProperty(field);
+ 	}
+
+ 	/**
+ 	 * 
+ 	 * @return true <i>if field equals true</i> false <i>if field does not equals true</i>
+ 	 */
+    public boolean getBoolean(String field) {
+        try {
+            return get(field).toLowerCase().contains("true");
+        } catch (FileNotFoundException e) {
+            System.out.println("ERROR!");
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/PluginReference/src/main/java/PluginReference/configuration/xml/XmlConfiguration.java
+++ b/PluginReference/src/main/java/PluginReference/configuration/xml/XmlConfiguration.java
@@ -1,0 +1,55 @@
+package PluginReference.configuration.xml;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+/**
+ * XML configuration setup for Rainbow.
+ *
+ * <br><a href="https://www.tutorialspoint.com/java_xml/java_dom_parse_document.htm">Based on Java XML DOM example</a>
+ * 
+ * @author Isaiah Patton
+ */
+public class XmlConfiguration {
+    public File file;
+    public DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    
+    public XmlConfiguration(File f) {
+        this.file = f;
+    }
+
+    /**
+     * Sets field to new text
+     */
+    public void set(String nodeName, String newText) throws ParserConfigurationException, SAXException, IOException {
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(file);
+        doc.getDocumentElement().normalize();
+        doc.getAttributes().getNamedItem(nodeName).setNodeValue(newText);
+ 
+    }
+    
+    /**
+     * Returns the field text.
+     * 
+     * @return String
+     */
+    public String get(String nodeName) throws ParserConfigurationException, SAXException, IOException {
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(file);
+        doc.getDocumentElement().normalize();
+        Node n = doc.getAttributes().getNamedItem(nodeName);
+
+        return n.getNodeValue();
+    }
+}


### PR DESCRIPTION
Add configuration, like how Bukkit had YAML but this is with [XML](https://en.wikipedia.org/wiki/XML) and Java's [.properties](https://en.wikipedia.org/wiki/.properties).

https://en.wikipedia.org/wiki/.properties
https://en.wikipedia.org/wiki/XML

**Adds classes:**
PluginReference.configuration.xml.XmlConfiguration
PluginReference.configuration.prop.PropConfiguration